### PR TITLE
Configurable duration resolution option

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "jquery": "^3.2.1",
     "lodash": "^4.17.10",
-    "moment": "^2.22.1"
+    "moment": "^2.22.1",
+    "uglifyjs-webpack-plugin": "^2.0.1"
   },
   "devDependencies": {
     "grafana-sdk-mocks": "github:ryantxu/grafana-sdk-mocks",

--- a/src/partials/editor.options.html
+++ b/src/partials/editor.options.html
@@ -75,6 +75,20 @@
             label-class="gf-form-label width-14"
             checked="ctrl.panel.highlightOnMouseover"
             on-change="ctrl.onConfigChanged()"></gf-form-switch>
+
+        <gf-form-switch class="gf-form"
+            label="Use Custom Precision"
+            label-class="gf-form-label width-14"
+            checked="ctrl.panel.useTimePrecision"
+            on-change="ctrl.onConfigChanged()"></gf-form-switch>
+        <div class="gf-form-select-wrapper max-width-14" ng-show="ctrl.panel.useTimePrecision">
+          <select class="gf-form-input"
+            ng-model="ctrl.panel.timePrecision"
+            ng-options="option.name for option in ctrl.panel.timeOptions track by option.value"
+            ng-change="ctrl.onConfigChanged()">
+          </select>
+        </div>
+
     </div>
 
     <div class="section gf-form-group">


### PR DESCRIPTION
It's now possible to display a more accurate duration by selecting
the "Use Time Precision" option.

Also adding the dependency `uglifyjs-webpack-plugin` as is required
to build.

![image](https://user-images.githubusercontent.com/42357661/49316836-7c7fbb00-f4af-11e8-8d35-a5fa47200b7e.png)
