### PR TITLE
Follow preferences for timezone if not overridden on dashboard

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1019,7 +1019,7 @@ class DiscretePanelCtrl extends CanvasPanelCtrl {
 
     const timeFormat = this.time_format(max - min, timeResolution / 1000);
     let displayOffset = 0;
-    if (this.dashboard.timezone === 'utc') {
+    if ((this.dashboard.timezone === 'utc') || (this.contextSrv.user.timezone === 'utc')) {
       displayOffset = new Date().getTimezoneOffset() * 60000;
     }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -1019,7 +1019,7 @@ class DiscretePanelCtrl extends CanvasPanelCtrl {
 
     const timeFormat = this.time_format(max - min, timeResolution / 1000);
     let displayOffset = 0;
-    if ((this.dashboard.timezone === 'utc') || (this.contextSrv.user.timezone === 'utc')) {
+    if (this.dashboard.isTimezoneUtc()) {
       displayOffset = new Date().getTimezoneOffset() * 60000;
     }
 


### PR DESCRIPTION
Rather than checking this.dashboard.timezone, make use of the `isTimezoneUtc()` function so that preferences are checked too 

Should resolve https://github.com/NatelEnergy/grafana-discrete-panel/issues/94


Browser time:
![image](https://user-images.githubusercontent.com/22746/67040752-07938f00-f11c-11e9-98a2-b2ef050f01bc.png)


Picking up preference default of UTC:
![image](https://user-images.githubusercontent.com/22746/67040789-1bd78c00-f11c-11e9-8cab-53c472f17bf1.png)

