### PR TITLE
Fix start date in hover popup

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -584,6 +584,11 @@ class DiscretePanelCtrl extends CanvasPanelCtrl {
     this.$tooltip.html(body).place_tt(pageX + 20, pageY + 5);
   }
 
+  getCorrectTime(ts: number) {
+    const from = moment(this.range.from).valueOf();
+    return (ts < from ? from : ts);
+  }
+
   onGraphHover(evt, showTT, isExternal) {
     this.externalPT = false;
     if (this.data && this.data.length) {
@@ -604,6 +609,9 @@ class DiscretePanelCtrl extends CanvasPanelCtrl {
           }
           hover = this.data[j].changes[i];
         }
+
+        hover.start = this.getCorrectTime(hover.start);
+
         this.hoverPoint = hover;
 
         if (this.annotations && !isExternal && this._renderDimensions) {


### PR DESCRIPTION
Hello,

Currently the dates which appear in the over popup are not correct if some points are not in the panel range.

Example : 
![image](https://user-images.githubusercontent.com/46566099/79338604-e0314980-7f27-11ea-97c3-dfa2d1b5b181.png)
Here, the panel range starts at 12:50 but due to my query I have a first point at 10:09:48.
In this case you can see that dates in the popup are not consistent with dates on the graph.

Thats's why I suggest this pull request.

Thanks
